### PR TITLE
Add baseevents Dependency & Remove Non-Existent Export

### DIFF
--- a/disc-hud/__resource.lua
+++ b/disc-hud/__resource.lua
@@ -29,5 +29,9 @@ server_scripts {
 	'server/main.lua',
 }
 exports {
-  'setVoice'
+	'setVoice'
+}
+
+dependencies {
+	'baseevents'
 }

--- a/disc-hud/__resource.lua
+++ b/disc-hud/__resource.lua
@@ -15,21 +15,17 @@ files {
 	'html/js/app.js',
 	'html/index.html',
 
-    'html/css/jquery-ui.min.css',
-    'html/js/jquery.min.js',
-    'html/js/jquery-ui.min.js',
+	'html/css/jquery-ui.min.css',
+	'html/js/jquery.min.js',
+	'html/js/jquery-ui.min.js',
 }
 
 client_scripts {
 	'client/client.lua',
-	--'client/main.lua',
 }
 
 server_scripts {
 	'server/main.lua',
-}
-exports {
-	'setVoice'
 }
 
 dependencies {


### PR DESCRIPTION
So people stop asking why it doesn't work, it won't let them start it without the required dependency