### PR TITLE
Fixed mispellings

### DIFF
--- a/disc-warrant/sql/disc-warrant.sql
+++ b/disc-warrant/sql/disc-warrant.sql
@@ -2,8 +2,8 @@ CREATE TABLE IF NOT EXISTS warrants
 (
     id                BIGINT UNSIGNED AUTO_INCREMENT,
     identifier        TEXT              NULL,
-    crime_decription TEXT              NULL,
-    char_decription  TEXT              NULL,
+    crime_description TEXT              NULL,
+    char_description  TEXT              NULL,
     active            TINYINT DEFAULT 1 NULL,
     code              VARCHAR(10)       NOT NULL,
     CONSTRAINT id


### PR DESCRIPTION
Fixed the crime_description and char_description both mispelled causing the script not to save any warrants.