### PR TITLE
Fixed Sniper mispelling and pistol ammo limit

### DIFF
--- a/disc-ammo/sql/disc-ammo.sql
+++ b/disc-ammo/sql/disc-ammo.sql
@@ -12,7 +12,7 @@ alter table disc_ammo
     add primary key (id);
 
 
-INSERT INTO essentialmode.items (`name`, `label`, `limit`, `rare`, `can_remove`) VALUES ('disc_ammo_pistol', 'Pistol Ammo', -10, 0, 1);
+INSERT INTO essentialmode.items (`name`, `label`, `limit`, `rare`, `can_remove`) VALUES ('disc_ammo_pistol', 'Pistol Ammo', 10, 0, 1);
 INSERT INTO essentialmode.items (`name`, `label`, `limit`, `rare`, `can_remove`) VALUES ('disc_ammo_pistol_large', 'Pistol Ammo Large', -10, 0, 1);
 INSERT INTO essentialmode.items (`name`, `label`, `limit`, `rare`, `can_remove`) VALUES ('disc_ammo_rifle', 'Rifle Ammo', 10, 0, 1);
 INSERT INTO essentialmode.items (`name`, `label`, `limit`, `rare`, `can_remove`) VALUES ('disc_ammo_rifle_large', 'Rifle Ammo Large', 10, 0, 1);
@@ -20,5 +20,5 @@ INSERT INTO essentialmode.items (`name`, `label`, `limit`, `rare`, `can_remove`)
 INSERT INTO essentialmode.items (`name`, `label`, `limit`, `rare`, `can_remove`) VALUES ('disc_ammo_shotgun_large', 'Shotgun Shells Large', 10, 0, 1);
 INSERT INTO essentialmode.items (`name`, `label`, `limit`, `rare`, `can_remove`) VALUES ('disc_ammo_smg', 'SMG Ammo', 10, 0, 1);
 INSERT INTO essentialmode.items (`name`, `label`, `limit`, `rare`, `can_remove`) VALUES ('disc_ammo_smg_large', 'SMG Ammo Large', 10, 0, 1);
-INSERT INTO essentialmode.items (`name`, `label`, `limit`, `rare`, `can_remove`) VALUES ('disc_ammo_snp', 'Sinper Ammo', 10, 0, 1);
-INSERT INTO essentialmode.items (`name`, `label`, `limit`, `rare`, `can_remove`) VALUES ('disc_ammo_snp_large', 'Sinper Ammo Large', 10, 0, 1);
+INSERT INTO essentialmode.items (`name`, `label`, `limit`, `rare`, `can_remove`) VALUES ('disc_ammo_snp', 'Sniper Ammo', 10, 0, 1);
+INSERT INTO essentialmode.items (`name`, `label`, `limit`, `rare`, `can_remove`) VALUES ('disc_ammo_snp_large', 'Sniper Ammo Large', 10, 0, 1);


### PR DESCRIPTION
Fixed the Sniper mispelling and also changed -10 for ammo_pistol to 10 as -10 causes issues when using the ammo and gives unlimited  causing it to lock up the inventory