### PR TITLE
Show drops when join to server

### DIFF
--- a/disc-inventoryhud/server/drop.lua
+++ b/disc-inventoryhud/server/drop.lua
@@ -24,6 +24,11 @@ Citizen.CreateThread(function()
     end)
 end)
 
+AddEventHandler('esx:playerLoaded', function(data)
+    Citizen.Wait(5000)
+    TriggerClientEvent('disc-inventoryhud:updateDrops', data, drops)
+end)
+
 RegisterServerEvent('disc-inventoryhud:modifiedInventory')
 AddEventHandler('disc-inventoryhud:modifiedInventory', function(identifier, type, data)
     if type == 'drop' then


### PR DESCRIPTION
@DiscworldZA Hello. when you join to server, drops not visible and this code can fixed this bug.
--- ---
Please work on [crafting] system, i need that. crafting have some bugs.
--- --- Bug 1:
For exmple: Recipe -> [water] - bread - [water]
if you have just 1 water in inventory, you can make this recipe.
--- --- Bug 2:
Crafting system not sync with disc-inventoryhud.
For example: i have only 2 water and i made one recipe -> [water] - [bread] - [water]
and when --( [Disc-InventoryHud][SAVED] All Inventories )-- occur, now in my inventory 2 water come back. this is duplicate bug.
--- --- Bug 3:
If i have 3 WEAPON_PISTOL in my inventory and
when i'm in crafting menu, WEAPON_PISTOL which have weight = 1 , is not shown in 3 slot.
all 3 WEAPON_PISTOL just in 1 slot and shown sum of weapons. i mean shown 3.
this is not good, because when i make one recipe, items which have weight = 1, jump to my inventory all together and bug generated. in my sever this is a bug.
Seriously and extremely this event not good for my own coding.
please seperate cooked item in crafting system exactly similar disc-inventoryhud.
--- --- Bug 4:
["usable":false] or ["usable":true] for cooked items not set in crafting system.
--- --- Done
Thank you so much