### PR TITLE
[disc-death] fix ESC not working after player death

### DIFF
--- a/disc-death/__resource.lua
+++ b/disc-death/__resource.lua
@@ -2,7 +2,7 @@ resource_manifest_version '44febabe-d386-4d18-afbe-5e627f4af937'
 
 description 'Disc Death'
 
-version '1.0.0'
+version '1.0.1'
 
 client_scripts {
     'config.lua',

--- a/disc-death/client/death.lua
+++ b/disc-death/client/death.lua
@@ -76,6 +76,10 @@ Citizen.CreateThread(function()
 end)
 
 function Revive(playerPed)
+    Coords = GetEntityCoords(playerPed)
+    Heading = GetEntityHeading(playerPed)
+    NetworkResurrectLocalPlayer(Coords.x, Coords.y, Coords.z, Heading, true, false)
+    
     TriggerServerEvent('disc-death:setDead', false)
     TriggerEvent('disc-death:onPlayerRevive')
     isDead = false


### PR DESCRIPTION
This took some time figuring out. The game itself actually disables the ESC while it detects the player as dead. NetworkResurrectLocalPlayer() is the native that you have to use for the game to know that the player is alive after being dead.